### PR TITLE
Tweak textarea/liner handling

### DIFF
--- a/css/lined.css
+++ b/css/lined.css
@@ -64,5 +64,6 @@
 }
 
 .linedwrap .codelines .lineselect {
-  color: red;
+  background: red;
+  color: white;
 }

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
                 </div>
                 <hr>
                 <p>Input the lyrics in the box below with the same syntax as it shows</p>
-                <textarea id="lyricsInputArea" placeholder="First phrase on the first line&#x0a;Sec-ond phrase on sec-ond line&#x0a;And syl-lab-les get sep-a-rat-ed with dash-es&#x0a;&#x0a;Al-so an emp-ty line doesn't mat-ter" onchange="writeLyrics()"></textarea>
+                <textarea id="lyricsInputArea" placeholder="First phrase on the first line&#x0a;Sec-ond phrase on sec-ond line&#x0a;And syl-lab-les get sep-a-rat-ed with dash-es&#x0a;&#x0a;Al-so an emp-ty line doesn't mat-ter"></textarea>
                 <br>
                 <label for="restoreButton">Use this button to get last stored lyrics (gets saved every time the text field is unfocused)</label>
                 <br>

--- a/js/lined.js
+++ b/js/lined.js
@@ -39,18 +39,30 @@
      * Helper function to make sure the line numbers are always
      * kept up to the current system
      */
-    var fillOutLines = function(codeLines, h, lineNo){
-      while ( (codeLines.height() - h ) <= 0 ){
-        if ( lineNo == opts.selectedLine )
-          codeLines.append("<div class='lineno lineselect'>" + lineNo + "</div>");
-        else
-          codeLines.append("<div class='lineno'>" + lineNo + "</div>");
-
-        lineNo++;
+    const lines = [];
+    const fillOutLines = (codeLines, h, lineNo, textarea) => {
+      const textLines = textarea.val().split("\n");
+      for (let i = lineNo; i <= textLines.length; i++) {
+        const line = $(`<div class="lineno">&nbsp;</div>`);
+        lines.push(line);
+        codeLines.append(line);
+        if (!textLines[i]) continue;
+        if (~opts.selectedLines.indexOf(lineNo)) line.addClass("lineselect");
+        line.html(lineNo++);
+        if (codeLines.height() >= h) break;
       }
+      let l = 1;
+      lines.forEach((line, i) => {
+        if (~opts.selectedLines.indexOf(l)) {
+          line.addClass("lineselect");
+        } else {
+          line.removeClass("lineselect");
+        }
+        if (textLines[i]) line.html(l++);
+        else line.html("&nbsp;");
+      });
       return lineNo;
     };
-
 
     /*
      * Iterate through each of the elements are to be applied to
@@ -78,7 +90,7 @@
       /* Draw the number bar; filling it out where necessary */
       linesDiv.append( "<div class='codelines'></div>" );
       var codeLinesDiv  = linesDiv.find(".codelines");
-      lineNo = fillOutLines( codeLinesDiv, linesDiv.height(), 1 );
+      lineNo = fillOutLines( codeLinesDiv, linesDiv.height(), 1, textarea);
 
       /* Move the textarea to the selected line */
       if ( opts.selectedLine != -1 && !isNaN(opts.selectedLine) ){
@@ -100,13 +112,20 @@
 
 
       /* React to the scroll event */
-      textarea.scroll( function(tn){
+      const update = function(args){
+        if (args.selectedLines) opts.selectedLines = args.selectedLines;
         var domTextArea   = $(this)[0];
         var scrollTop     = domTextArea.scrollTop;
         var clientHeight  = domTextArea.clientHeight;
         codeLinesDiv.css( {'margin-top': (-1*scrollTop) + "px"} );
-        lineNo = fillOutLines( codeLinesDiv, scrollTop + clientHeight, lineNo );
-      });
+        lineNo = fillOutLines( codeLinesDiv, scrollTop + clientHeight, lineNo, textarea);
+      };
+      textarea.on("input propertychange", update);
+      textarea.scroll(update);
+      // Awful hack: add "update" to global so it can be reached from
+      // mainScripts.js/testLyricEventsAndSyllables()
+      // (there's only one linedtextarea so it should be fine, I guess)
+      global.updateLinedTextArea = update;
 
 
       /* Should the textarea get resized outside of our control */
@@ -121,6 +140,7 @@
   // default options
   $.fn.linedtextarea.defaults = {
     selectedLine: -1,
+    selectedLines: [],
     selectedClass: 'lineselect'
   };
 })($);

--- a/mainScripts.js
+++ b/mainScripts.js
@@ -94,6 +94,7 @@ function writeLyrics() {
     }
     changeFields();
 }
+$("#lyricsInputArea").on("input propertychange", writeLyrics);
 
 // Button to restore the last lyric input from the config file
 function restoreFromConfig() {
@@ -358,7 +359,7 @@ function readLyricInput() {
     for (var i = 0; i < lyricsInputFull.length; i++) {
         if (lyricsInputFull[i] != "") {
             var tempArr = [];
-            var tempPhrase = lyricsInputFull[i].replace(/-/g, "- ").replace(/=/g, "= ").trim().split(" ");
+            var tempPhrase = lyricsInputFull[i].replace(/-/g, "- ").trim().split(" ");
 
             for (var j = 0; j < tempPhrase.length; j++) {
                 if (tempPhrase[j] != "" && tempPhrase[j] != "-") {
@@ -392,6 +393,19 @@ function testLyricEventsAndSyllables() {
     } else {
         morePhrases = lyricsInputArray.length;
     }
+
+    const lines = new Array(morePhrases).fill(0).map((_, i) => ({
+        index: i+1,
+        nbWordsChart: (eventsPhraseArray[i] || []).length,
+        nbWordsLyrics: (lyricsInputArray[i] || []).length
+    }));
+    global.updateLinedTextArea({
+        selectedLines: lines
+            .filter(({
+                nbWordsLyrics, nbWordsChart
+            }) => nbWordsLyrics != nbWordsChart)
+            .map(({ index }) => index)
+    });
 
     for (var i = 0; i < morePhrases; i++) {
         var newSpan = document.createElement("span");


### PR DESCRIPTION
* Move `writeLyrics` from the textarea `onchange` to an `$("#textarea").on("input propertychange")` so the lyric stats update as you type
* Hack line numbering plugin so that empty lines are not numbered
* Highlight the line number in red on lyric/event syllable number mismatch