### PR TITLE
Just build lyricadder for Linux and Mac

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
  "scripts": {
   "start": "electron .",
   "test": "echo \"Error: no test specified\" && exit 1",
-  "package-mac": "electron-packager . --overwrite --platform=darwin --arch=x64 --icon=assets/icons/mac/icon.icns --prune=true --out=release-builds",
+  "package-mac": "electron-packager . lyricadder --overwrite --platform=darwin --arch=x64 --icon=assets/icons/mac/icon.icns --prune=true --out=release-builds",
   "package-win": "electron-packager . lyricadder --overwrite --asar=true --platform=win32 --arch=ia32 --prune=true --out=release-builds --version-string.CompanyName=CE --version-string.FileDescription=CE --version-string.ProductName=\"LyricAdder\"",
-  "package-linux": "electron-packager . lyricadder-linux --overwrite --asar=true --platform=linux --arch=x64 --icon=assets/icons/png/1024x1024.png --prune=true --out=release-builds"
+  "package-linux": "electron-packager . lyricadder --overwrite --asar=true --platform=linux --arch=x64 --icon=assets/icons/png/1024x1024.png --prune=true --out=release-builds"
  },
  "repository": {
   "type": "git",


### PR DESCRIPTION
Since lyricadder-linux is not a separately defined package and there was no package defined for mac